### PR TITLE
Delegate keyword arguments for Ruby 3.0

### DIFF
--- a/lib/brakeman/plugin.rb
+++ b/lib/brakeman/plugin.rb
@@ -33,14 +33,12 @@ module Danger
 
     def _add_warning_for_each_line(brakeman_result)
       brakeman_result.each do |warning|
-        arguments = [
-          "[brakeman] #{warning['message']}",
-          {
-            file: warning['file'],
-            line: warning['line']
-          }
-        ]
-        warn(*arguments)
+        offense_message = "[brakeman] #{warning['message']}"
+        kw_args = {
+          file: warning['file'],
+          line: warning['line']
+        }
+        warn(offense_message, **kw_args)
       end
     end
 


### PR DESCRIPTION
参考：https://github.com/ashfurrow/danger-rubocop/pull/56
実害：https://app.circleci.com/pipelines/github/jmty/beagle/33317/workflows/02c0b9ce-0291-4a0c-9a30-1ab2e8b21c02/jobs/72754

```
bundler: failed to load command: danger (/work/vendor/bundle/ruby/3.1.0/bin/danger)
/work/vendor/bundle/ruby/3.1.0/gems/kramdown-2.4.0/lib/kramdown/parser/base.rb:92:in `adapt_source': undefined method `valid_encoding?' for {:file=>"app/controllers/admin/articles_controller.rb", :line=>51}:Hash (NoMethodError)

        unless source.valid_encoding?
                     ^^^^^^^^^^^^^^^^
	from /work/vendor/bundle/ruby/3.1.0/gems/kramdown-2.4.0/lib/kramdown/parser/kramdown.rb:90:in `parse'
	from /work/vendor/bundle/ruby/3.1.0/gems/kramdown-parser-gfm-1.1.0/lib/kramdown/parser/gfm.rb:56:in `parse'
	from /work/vendor/bundle/ruby/3.1.0/gems/kramdown-2.4.0/lib/kramdown/parser/base.rb:69:in `parse'
	from /work/vendor/bundle/ruby/3.1.0/gems/kramdown-2.4.0/lib/kramdown/document.rb:102:in `initialize'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:14:in `new'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:14:in `markdown_parser'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:52:in `process_markdown'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:60:in `block in table'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:60:in `map'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:60:in `table'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/helpers/comments_helper.rb:99:in `generate_comment'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/request_sources/github/github.rb:188:in `update_pull_request!'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/danger_core/dangerfile.rb:264:in `post_results'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/danger_core/dangerfile.rb:292:in `run'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/danger_core/executor.rb:29:in `run'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/lib/danger/commands/runner.rb:73:in `run'
	from /work/vendor/bundle/ruby/3.1.0/gems/claide-1.1.0/lib/claide/command.rb:334:in `run'
	from /work/vendor/bundle/ruby/3.1.0/gems/danger-9.0.0/bin/danger:5:in `<top (required)>'
	from /work/vendor/bundle/ruby/3.1.0/bin/danger:25:in `load'
```